### PR TITLE
Send details in Hash instead of description

### DIFF
--- a/lib/lognotifier/application.rb
+++ b/lib/lognotifier/application.rb
@@ -63,7 +63,7 @@ module Lognotifier
               message += previous.chomp + ' | ' unless previous.nil? || previous == content
               message += content.chomp
               begin
-                pagerduty.trigger("#{pattern['prefix']} #{message}")
+                pagerduty.trigger("#{pattern['prefix']}", {'details' => message})
                 @logger.info("ALERT TRIGGERD - #{pattern['prefix']}: #{message}")
               rescue => e
                 @logger.error("FAILED TO SEND ALERT: #{pattern['prefix']} #{message}")


### PR DESCRIPTION
Hi @juanbrein,

We've had a problem with the alert system lately, the max length for description seems to have changed in PagerDuty's API even though it's not stated in their API doc.
We've found the following info in their Ruby gem documentation so we went ahead and passed the stacktrace in the details object on calling for the trigger method.
https://github.com/envato/pagerduty/blob/master/lib/pagerduty.rb#L44-L45

Thank you.